### PR TITLE
fix: element text extends element node

### DIFF
--- a/src/elementNode.ts
+++ b/src/elementNode.ts
@@ -148,6 +148,7 @@ export type Styles = {
 /** Node text, children of a ElementNode of type TextNode */
 export interface ElementText
   extends Partial<Omit<ITextNode, 'id' | 'parent' | 'shader'>>,
+    Partial<Omit<ElementNode, '_type'>>,
     IntrinsicTextStyleCommonProps {
   id?: string;
   _type: 'text';


### PR DESCRIPTION
Extended Element Text with Element Node for properties that don't exist on type `'ElementNode | ElementText'` such as `skipFocus` which was causing failures in solid-UI.