### PR TITLE
Add @lightningtv/source export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,17 +3,20 @@
   "version": "2.7.6-0",
   "description": "Lightning TV Core for Universal Renderers",
   "type": "module",
-  "main": "./dist/src/index.js",
-  "browser": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": {
+        "@lightningtv/source": "./src/index.ts",
+        "types": "./dist/src/index.d.ts",
+        "default": "./dist/src/index.js"
+      }
     },
     "./focusManager": {
-      "types": "./dist/src/focusManager.d.ts",
-      "import": "./dist/src/focusManager.js"
+      "import": {
+        "@lightningtv/source": "./src/focusManager.ts",
+        "types": "./dist/src/focusManager.d.ts",
+        "default": "./dist/src/focusManager.js"
+      }
     }
   },
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lightningjs/renderer':
-        specifier: ^2.6.2
-        version: 2.6.2
+        specifier: ^2.13.0
+        version: 2.13.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.15.0
@@ -267,8 +267,8 @@ packages:
     resolution: {integrity: sha512-m+Trk77mp54Zma6xLkLuY+mvanPxlE4A7yNKs2HBiyZ4UkVs28Mv5c/pgWrHeInx+USHeX/WEPzjrWrcJiQgjw==}
     engines: {node: '>=18'}
 
-  '@lightningjs/renderer@2.6.2':
-    resolution: {integrity: sha512-agu9jV8hhbF/Ld8BJSogOJIQZBoSUzow+3BtP4NptqC3l1aV6RQr1rwpXQF12ITYjUi3CrfA7eV76GIiLAkOAA==}
+  '@lightningjs/renderer@2.13.2':
+    resolution: {integrity: sha512-IUh9OFEpUk0cnnLVw6OqW2m+CzmT2aOkLFzxuErC2xajhDKMRBCMe+kM+W26zqnc7SMSkkW3zs10oAKnrbzPsA==}
     engines: {node: '>= 20.9.0', npm: '>= 10.0.0', pnpm: '>= 8.9.2'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2035,7 +2035,7 @@ snapshots:
 
   '@inquirer/figures@1.0.7': {}
 
-  '@lightningjs/renderer@2.6.2': {}
+  '@lightningjs/renderer@2.13.2': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
A custom export condition allows for the source to be used by typescript/vite directly, without rebuilding, with minimal configuration, while not affecting those who do not enable it.

All thats necessary to use it:

```ts
// vite config
export default defineConfig({
  resolve: {
    conditions: ["@lightningtv/source"],
  },
});
```

```jsonc
// ts config
{
  "compilerOptions": {
    "customConditions": ["@lightningtv/source"],
  }
}
```

It's taken from [this article](https://colinhacks.com/essays/live-types-typescript-monorepo) and it works pretty well. I use it in solid-primitives and solid-devtools monorepos, but it should also work for linking packages with pnpm link.

I also removed the "main", "types" and "browser" fields because they are used by old cjs tools, which this package doesn't support anyway.