### PR TITLE
Update layout for child removal and parent swapping

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,6 +80,19 @@ export function keyExists(
   return false;
 }
 
+export function spliceItem<T>(
+  arr: T[],
+  item: T,
+  deleteCount: number,
+  ...insert: T[]
+): number {
+  const index = arr.indexOf(item);
+  if (index > -1) {
+    arr.splice(index, deleteCount, ...insert);
+  }
+  return index;
+}
+
 export function flattenStyles(
   obj: Styles | undefined | (Styles | undefined)[],
   result: Styles = {},


### PR DESCRIPTION
Ensure layout updates when a child node is removed or a parent node is swapped
Also introduce a utility function for array item splicing