### PR TITLE
Correct line-height calculation for 'both' contain

### DIFF
--- a/src/domRenderer.ts
+++ b/src/domRenderer.ts
@@ -341,6 +341,7 @@ function updateNodeStyles(node: DOMNode | DOMText) {
       case 'both': {
         let lineHeight = getNodeLineHeight(textProps);
         maxLines = Math.min(maxLines, Math.floor(props.height / lineHeight));
+        maxLines = Math.max(1, maxLines);
         let height = maxLines * lineHeight;
         style += `width: ${props.width}px; height: ${height}px; overflow: hidden;`;
         break;


### PR DESCRIPTION
Ensure that the maximum lines calculated for the 'both' contain type is at least one when the height is less than the line height.