### PR TITLE
Declare static configuration using global vars

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,36 @@ import type {
 } from './intrinsicTypes.js';
 import { type ElementNode } from './elementNode.js';
 
+/**
+  STATIC LIGHTNING CONFIGURATION \
+  Replace the values below with in your build system, \
+  or set them in the global scope before importing lightning-core.
+*/
+declare global {
+  /** Whether the DOM renderer should be used instead of `@lightningjs/renderer` */
+  var __LIGHTNING_DOM_RENDERING__: boolean | undefined;
+  /** Whether element shaders should be disabled */
+  var __LIGHTNING_DISABLE_SHADERS__: boolean | undefined;
+}
+
+export const isDev = !!(import.meta.env && import.meta.env.DEV);
+
+/** Whether the DOM renderer is used instead of `@lightningjs/renderer` */
+export const DOM_RENDERING =
+  typeof __LIGHTNING_DOM_RENDERING__ === 'boolean' &&
+  __LIGHTNING_DOM_RENDERING__;
+
+/** Whether element shaders are enabled */
+export const SHADERS_ENABLED = !(
+  typeof __LIGHTNING_DISABLE_SHADERS__ === 'boolean' &&
+  __LIGHTNING_DISABLE_SHADERS__
+);
+
+/**
+  RUNTIME LIGHTNING CONFIGURATION \
+  This configuration can be set at runtime, but it is recommended to set it
+  before running any Lightning modules to ensure consistent behavior across the application.
+*/
 export interface Config {
   debug: boolean;
   focusDebug: boolean;
@@ -18,12 +48,6 @@ export interface Config {
   focusStateKey: DollarString;
   lockStyles?: boolean;
 }
-
-export const isDev = !!(import.meta.env && import.meta.env.DEV);
-
-export const SHADERS_ENABLED = !(
-  import.meta.env && import.meta.env.VITE_DISABLE_SHADERS === 'true'
-);
 
 export const Config: Config = {
   debug: false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,22 +13,20 @@ import { type ElementNode } from './elementNode.js';
 */
 declare global {
   /** Whether the DOM renderer should be used instead of `@lightningjs/renderer` */
-  var __LIGHTNING_DOM_RENDERING__: boolean | undefined;
+  var LIGHTNING_DOM_RENDERING: boolean | undefined;
   /** Whether element shaders should be disabled */
-  var __LIGHTNING_DISABLE_SHADERS__: boolean | undefined;
+  var LIGHTNING_DISABLE_SHADERS: boolean | undefined;
 }
 
 export const isDev = !!(import.meta.env && import.meta.env.DEV);
 
 /** Whether the DOM renderer is used instead of `@lightningjs/renderer` */
 export const DOM_RENDERING =
-  typeof __LIGHTNING_DOM_RENDERING__ === 'boolean' &&
-  __LIGHTNING_DOM_RENDERING__;
+  typeof LIGHTNING_DOM_RENDERING === 'boolean' && LIGHTNING_DOM_RENDERING;
 
 /** Whether element shaders are enabled */
 export const SHADERS_ENABLED = !(
-  typeof __LIGHTNING_DISABLE_SHADERS__ === 'boolean' &&
-  __LIGHTNING_DISABLE_SHADERS__
+  typeof LIGHTNING_DISABLE_SHADERS === 'boolean' && LIGHTNING_DISABLE_SHADERS
 );
 
 /**

--- a/src/lightningInit.ts
+++ b/src/lightningInit.ts
@@ -1,6 +1,6 @@
 import * as lng from '@lightningjs/renderer';
 import { DOMRendererMain } from './domRenderer.js';
-import { Config } from './config.js';
+import { DOM_RENDERING } from './config.js';
 
 export type SdfFontType = 'ssdf' | 'msdf';
 
@@ -106,7 +106,7 @@ export function startLightningRenderer(
   options: lng.RendererMainSettings,
   rootId: string | HTMLElement = 'app',
 ) {
-  renderer = Config.domRendering
+  renderer = DOM_RENDERING
     ? new DOMRendererMain(options, rootId)
     : (new lng.RendererMain(options, rootId) as any as IRendererMain);
   return renderer;


### PR DESCRIPTION
Introduce global variables for static configuration settings.

This way the module could be easily configured with `define` when using a bundler: https://esbuild.github.io/api/#define

```ts
vite.defineConfig({
  define: {
    LIGHTNING_DOM_RENDERING: DEVICE === 'playstation',
    LIGHTNING_DISABLE_SHADERS: true,
  },
  ...
})

esbuild.build({
  define: {
    LIGHTNING_DOM_RENDERING: String(DEVICE === 'playstation'),
    LIGHTNING_DISABLE_SHADERS: 'true',
  },
  ...
})
```

Or at runtime if necessary
```ts
globalThis.LIGHTNING_DOM_RENDERING = true
import '@lightningtv/core'
```