### PR TITLE
Remove `undefined` from `AnimationSettings` type

### DIFF
--- a/src/elementNode.ts
+++ b/src/elementNode.ts
@@ -243,7 +243,10 @@ export interface ElementNode extends RendererNode {
   width: number;
   height: number;
   zIndex?: number;
-  transition?: Record<string, AnimationSettings | true | false> | true | false;
+  transition?:
+    | Record<string, AnimationSettings | undefined | true | false>
+    | true
+    | false;
   /**
    * Optional handlers for animation events.
    *
@@ -679,7 +682,7 @@ export class ElementNode extends Object {
     return this._animationSettings || Config.animationSettings;
   }
 
-  set animationSettings(animationSettings: AnimationSettings) {
+  set animationSettings(animationSettings: AnimationSettings | undefined) {
     this._animationSettings = animationSettings;
   }
 

--- a/src/intrinsicTypes.ts
+++ b/src/intrinsicTypes.ts
@@ -12,7 +12,7 @@ import {
 import { ElementNode, type RendererNode } from './elementNode.js';
 import { NodeStates } from './states.js';
 
-export type AnimationSettings = Partial<RendererAnimationSettings> | undefined;
+export type AnimationSettings = Partial<RendererAnimationSettings>;
 
 export type AddColorString<T> = {
   [K in keyof T]: K extends `color${string}` ? string | number : T[K];


### PR DESCRIPTION
Eliminate the `| undefined` disjunction from `AnimationSettings` as it is not utilized in practice. Adjust related code to reflect this change.