### PR TITLE
Remove selectedNode getter

### DIFF
--- a/src/elementNode.ts
+++ b/src/elementNode.ts
@@ -397,20 +397,6 @@ export class ElementNode extends Object {
     }
   }
 
-  get selectedNode(): ElementNode | undefined {
-    const selectedIndex = this.selected || 0;
-
-    for (let i = selectedIndex; i < this.children.length; i++) {
-      const element = this.children[i];
-      if (isElementNode(element)) {
-        this.selected = i;
-        return element;
-      }
-    }
-
-    return undefined;
-  }
-
   set shader(
     shaderProps: IRendererShader | [kind: string, props: IRendererShaderProps],
   ) {


### PR DESCRIPTION
Removes `selectedNode` getter from `ElementNode`.
After https://github.com/lightning-tv/solid/pull/61 is merged, nothing is using this getter anymore.
Also this getter is weird in general, so it would be good to remove it.
  - it doesn't just return the current selected child, but searches for fist available when nothing is selected, even though it's not obvious from the name.
  - it mutates the element (`this.selected = i`)
  - it handles selection, which is a system introduced by lightning solid/primitives, not core.