### PR TITLE
Adapt core to be able to switch between using lngr 2 or 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
   ],
   "author": "Chris Lorenzo",
   "license": "Apache-2.0",
-  "peerDependencies": {
-    "@lightningjs/renderer": "^2.16.0"
+  "dependencies": {
+    "lngr2": "npm:@lightningjs/renderer@2.16.0",
+    "lngr3": "npm:@lightningjs/renderer@3.0.0-beta7"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,12 @@ importers:
 
   .:
     dependencies:
-      '@lightningjs/renderer':
-        specifier: ^2.16.0
-        version: 2.16.0
+      lngr2:
+        specifier: npm:@lightningjs/renderer@2.16.0
+        version: '@lightningjs/renderer@2.16.0'
+      lngr3:
+        specifier: npm:@lightningjs/renderer@3.0.0-beta7
+        version: '@lightningjs/renderer@3.0.0-beta7'
     devDependencies:
       '@eslint/js':
         specifier: ^9.15.0
@@ -396,6 +399,10 @@ packages:
   '@lightningjs/renderer@2.16.0':
     resolution: {integrity: sha512-TA0litV7/ZMgRjc54GvXavzjBJFSZ8T3z7ohel4dqE3Tw9N3hC3aBmkey6PpF4usQ8JemNBMNgj7/2gR7bINhw==}
     engines: {node: '>= 20.9.0', npm: '>= 10.0.0', pnpm: '>= 8.9.2'}
+
+  '@lightningjs/renderer@3.0.0-beta7':
+    resolution: {integrity: sha512-yY5sbDeK+hEPdMohKdAC+TyEEkCaFhNm5oYKRIbA/tAGl0qqhq7qOguUkbLQEfYy7BtUmDLyjBt6sI73a+oypQ==}
+    engines: {node: '>= 18.0.0', npm: '>= 10.0.0', pnpm: '>= 8.9.2'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2447,6 +2454,8 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@lightningjs/renderer@2.16.0': {}
+
+  '@lightningjs/renderer@3.0.0-beta7': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
-import type { RendererMainSettings } from '@lightningjs/renderer';
+import type * as lngr2 from 'lngr2';
+import type * as lngr3 from 'lngr3';
 import type {
   TextProps,
   AnimationSettings,
@@ -13,9 +14,13 @@ import { type ElementNode } from './elementNode.js';
 */
 declare global {
   /** Whether the DOM renderer should be used instead of `@lightningjs/renderer` */
-  var LIGHTNING_DOM_RENDERING: boolean | undefined;
+  var __LIGHTNING_DOM_RENDERING__: boolean | undefined;
   /** Whether element shaders should be disabled */
-  var LIGHTNING_DISABLE_SHADERS: boolean | undefined;
+  var __LIGHTNING_DISABLE_SHADERS__: boolean | undefined;
+  /** If should use `@lightningjs/renderer` v3 or v2 */
+  var __LIGHTNING_RENDERER_V3__: boolean | undefined;
+  /** Whether is in development environment */
+  var __DEV__: boolean | undefined;
 
   /** Could be set by vite or other bundler */
   interface ImportMetaEnv {
@@ -26,16 +31,27 @@ declare global {
   }
 }
 
-export const isDev = !!(import.meta.env && import.meta.env.DEV);
+export const isDev =
+  !!(import.meta.env && import.meta.env.DEV) ||
+  (typeof __DEV__ === 'boolean' && __DEV__);
+export const DEV = isDev;
 
 /** Whether the DOM renderer is used instead of `@lightningjs/renderer` */
 export const DOM_RENDERING =
-  typeof LIGHTNING_DOM_RENDERING === 'boolean' && LIGHTNING_DOM_RENDERING;
+  typeof __LIGHTNING_DOM_RENDERING__ === 'boolean' &&
+  __LIGHTNING_DOM_RENDERING__;
 
 /** Whether element shaders are enabled */
 export const SHADERS_ENABLED = !(
-  typeof LIGHTNING_DISABLE_SHADERS === 'boolean' && LIGHTNING_DISABLE_SHADERS
+  typeof __LIGHTNING_DISABLE_SHADERS__ === 'boolean' &&
+  __LIGHTNING_DISABLE_SHADERS__
 );
+/** If should use `@lightningjs/renderer` v3 or v2 */
+export const LIGHTNING_RENDERER_V3 =
+  typeof __LIGHTNING_RENDERER_V3__ === 'boolean' && __LIGHTNING_RENDERER_V3__;
+
+export type RendererOptions = lngr2.RendererMainSettings &
+  lngr3.RendererMainSettings;
 
 /**
   RUNTIME LIGHTNING CONFIGURATION \
@@ -50,7 +66,7 @@ export interface Config {
   animationSettings?: AnimationSettings;
   animationsEnabled: boolean;
   fontSettings: Partial<TextProps>;
-  rendererOptions?: Partial<RendererMainSettings>;
+  rendererOptions?: Partial<RendererOptions>;
   setActiveElement: (elm: ElementNode) => void;
   focusStateKey: DollarString;
   lockStyles?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,6 @@
 export * from './elementNode.js';
 export * from './lightningInit.js';
-export * from './nodeTypes.js';
 export * from './utils.js';
 export * from './intrinsicTypes.js';
 export * from './focusKeyTypes.js';
 export * from './config.js';
-export type * from '@lightningjs/renderer';
-export { type AnimationSettings } from './intrinsicTypes.js';
-// hopefully fix up webpack error
-import { assertTruthy, deg2Rad } from '@lightningjs/renderer/utils';
-export { assertTruthy, deg2Rad };
-// export type * from '@lightningjs/renderer/utils';

--- a/src/intrinsicTypes.ts
+++ b/src/intrinsicTypes.ts
@@ -1,21 +1,31 @@
-import {
-  type FadeOutEffectProps,
-  type GlitchEffectProps,
-  type GrayscaleEffectProps,
-  type AnimationSettings as RendererAnimationSettings,
-  type LinearGradientEffectProps,
-  type RadialGradientEffectProps,
-  type RadialProgressEffectProps,
-  type ITextNodeProps,
-  type HolePunchEffectProps,
-  type IAnimationController,
-  NodeLoadedPayload,
-  NodeFailedPayload,
-} from '@lightningjs/renderer';
+import type * as lngr2 from 'lngr2';
+import type * as lngr3 from 'lngr3';
 import { ElementNode, type RendererNode } from './elementNode.js';
 import { NodeStates } from './states.js';
+import {
+  ShaderBorderProps,
+  ShaderHolePunchProps,
+  ShaderLinearGradientProps,
+  ShaderRadialGradientProps,
+  ShaderRoundedProps,
+  ShaderShadowProps,
+} from './shaders.js';
+import { IRendererNodeProps, IAnimationController } from './lightningInit.js';
 
-export type AnimationSettings = Partial<RendererAnimationSettings>;
+export type AnimationSettings = Partial<
+  lngr2.AnimationSettings | lngr3.AnimationSettings
+>;
+
+/**
+ * Grab all the number properties of type T
+ */
+export type NumberProps<T> = {
+  [Key in keyof T as NonNullable<T[Key]> extends number ? Key : never]: number;
+};
+/**
+ * Properties of a Node used by the animate() function
+ */
+export type CoreNodeAnimateProps = NumberProps<IRendererNodeProps>;
 
 export type AddColorString<T> = {
   [K in keyof T]: K extends `color${string}` ? string | number : T[K];
@@ -27,38 +37,20 @@ export interface BorderStyleObject {
 }
 
 export type DollarString = `$${string}`;
-export type BorderStyle = number | BorderStyleObject;
+export type BorderStyle = BorderStyleObject;
 export type BorderRadius = number | number[];
 
 export interface Effects {
-  fadeOut?: FadeOutEffectProps;
-  linearGradient?: LinearGradientEffectProps;
-  radialGradient?: RadialGradientEffectProps;
-  radialProgressGradient?: RadialProgressEffectProps;
-  grayscale?: GrayscaleEffectProps;
-  glitch?: GlitchEffectProps;
-  radialProgress?: RadialProgressEffectProps;
-  holePunch?: HolePunchEffectProps;
+  linearGradient?: Partial<ShaderLinearGradientProps>;
+  radialGradient?: Partial<ShaderRadialGradientProps>;
+  holePunch?: Partial<ShaderHolePunchProps>;
+  shadow?: Partial<ShaderShadowProps>;
+  rounded?: Partial<ShaderRoundedProps>;
+  borderRadius?: Partial<BorderRadius>;
+  border?: Partial<ShaderBorderProps>;
 }
 
-export interface BorderEffects {
-  radius?: { radius: BorderRadius };
-  rounded?: { radius: BorderRadius };
-  border?: BorderStyle;
-  borderTop?: BorderStyle;
-  borderRight?: BorderStyle;
-  borderBottom?: BorderStyle;
-  borderLeft?: BorderStyle;
-}
-
-export type StyleEffects = Effects & BorderEffects;
-
-// Renderer should export EffectDesc
-export type ShaderEffectDesc = {
-  name?: string;
-  type: keyof StyleEffects;
-  props: StyleEffects[keyof StyleEffects];
-};
+export type StyleEffects = Effects;
 
 export type NewOmit<T, K extends PropertyKey> = {
   [P in keyof T as Exclude<P, K>]: T[P];
@@ -69,7 +61,12 @@ export type RemoveUnderscoreProps<T> = {
 };
 
 type RendererText = AddColorString<
-  Partial<Omit<ITextNodeProps, 'debug' | 'shader' | 'parent'>>
+  Partial<
+    Omit<
+      lngr2.ITextNodeProps & lngr3.ITextNodeProps,
+      'debug' | 'shader' | 'parent'
+    >
+  >
 >;
 
 type CleanElementNode = NewOmit<
@@ -187,9 +184,9 @@ export type AnimationEventHandler = (
   props?: any,
 ) => void;
 
-type EventPayloadMap = {
-  loaded: NodeLoadedPayload;
-  failed: NodeFailedPayload;
+export type EventPayloadMap = {
+  loaded: lngr2.NodeLoadedPayload | lngr3.NodeLoadedPayload | undefined;
+  failed: lngr2.NodeFailedPayload | lngr3.NodeFailedPayload;
   freed: Event;
   inBounds: Event;
   outOfBounds: Event;
@@ -197,9 +194,9 @@ type EventPayloadMap = {
   outOfViewport: Event;
 };
 
-type NodeEvents = keyof EventPayloadMap;
+export type NodeEvents = keyof EventPayloadMap;
 
-type EventHandler<E extends NodeEvents> = (
+export type EventHandler<E extends NodeEvents> = (
   target: ElementNode,
   event?: EventPayloadMap[E],
 ) => void;

--- a/src/lightningInit.ts
+++ b/src/lightningInit.ts
@@ -1,18 +1,32 @@
-import * as lng from '@lightningjs/renderer';
+import * as lngr2 from 'lngr2';
+import * as lngr3 from 'lngr3';
 import { DOMRendererMain } from './domRenderer.js';
-import { DOM_RENDERING } from './config.js';
+import {
+  DOM_RENDERING,
+  LIGHTNING_RENDERER_V3,
+  RendererOptions,
+} from './config.js';
+import {
+  ShaderBorderPrefixedProps,
+  ShaderHolePunchProps,
+  ShaderLinearGradientProps,
+  ShaderRadialGradientProps,
+  ShaderRoundedProps,
+  ShaderShadowPrefixedProps,
+} from './shaders.js';
+import { EventPayloadMap, NodeEvents } from './intrinsicTypes.js';
 
 export type SdfFontType = 'ssdf' | 'msdf';
 
-/** Based on {@link lng.CoreRenderer} */
+/** Based on {@link lngr2.CoreRenderer} */
 export interface IRendererCoreRenderer {
   mode: 'canvas' | 'webgl' | undefined;
 }
-/** Based on {@link lng.TrFontManager} */
+/** Based on {@link lngr2.TrFontManager} */
 export interface IRendererFontManager {
   addFontFace: (...a: any[]) => void;
 }
-/** Based on {@link lng.Stage} */
+/** Based on {@link lngr2.Stage} */
 export interface IRendererStage {
   root: IRendererNode;
   renderer: IRendererCoreRenderer;
@@ -24,87 +38,714 @@ export interface IRendererStage {
   };
 }
 
-/** Based on {@link lng.CoreShaderManager} */
+/** Based on {@link lngr2.CoreShaderManager} */
 export interface IRendererShaderManager {
   registerShaderType: (name: string, shader: any) => void;
 }
 
-/** Based on {@link lng.CoreShaderNode} */
+/** Based on {@link lngr2.CoreShaderNode} */
 export interface IRendererShader {
   shaderType: IRendererShaderType;
-  props?: IRendererShaderProps;
+  props?: IRendererShaderProps & { effects?: lngr2.EffectDescUnion[] };
   program?: {};
 }
-/** Based on {@link lng.CoreShaderType} */
+/** Based on {@link lngr2.CoreShaderType} */
 export interface IRendererShaderType {}
-export type IRendererShaderProps = Record<string, unknown>;
 
-/** Based on {@link lng.Texture} */
+export type IRendererShaderProps = Partial<ShaderBorderPrefixedProps> &
+  Partial<ShaderShadowPrefixedProps> &
+  Partial<ShaderRoundedProps> &
+  Partial<ShaderHolePunchProps> &
+  Partial<ShaderRadialGradientProps> &
+  Partial<ShaderLinearGradientProps>;
+
+/** Based on {@link lngr2.Texture} */
 export interface IRendererTexture {
   props: IRendererTextureProps;
-  type: lng.TextureType;
+  type: lngr2.TextureType;
 }
 export interface IRendererTextureProps {}
 
-export interface IEventEmitter {
-  on: (e: string, cb: (...a: any[]) => void) => void;
-}
-
-export interface IRendererNodeShaded extends IEventEmitter {
+export interface IRendererNodeShaded {
   stage: IRendererStage;
   id: number;
   animate: (
-    props: Partial<lng.INodeAnimateProps<any>>,
-    settings: Partial<lng.AnimationSettings>,
-  ) => lng.IAnimationController;
+    props: Partial<lngr2.INodeAnimateProps<any>>,
+    settings: Partial<lngr2.AnimationSettings>,
+  ) => IAnimationController;
   get absX(): number;
   get absY(): number;
+  on<E extends NodeEvents>(ev: E, cb: IRendererNodeOnCallback<E>): void;
+  destroy(): void;
+}
+export type IRendererNodeOnCallback<E extends NodeEvents> = (
+  node: IRendererNode,
+  data: EventPayloadMap[E],
+) => void;
+
+export type AnimationControllerState = 'stopped' | 'running' | 'paused';
+
+/** Based on {@link lngr2.IAnimationController} */
+export interface IAnimationController {
+  /**
+   * Start the animation
+   *
+   * @remarks
+   * If the animation is paused this method will resume the animation.
+   */
+  start(): IAnimationController;
+  /**
+   * Stop the animation
+   *
+   * @remarks
+   * Resets the animation to the start state
+   */
+  stop(): IAnimationController;
+  /**
+   * Pause the animation
+   */
+  pause(): IAnimationController;
+  /**
+   * Restore the animation to the original values
+   */
+  restore(): IAnimationController;
+  /**
+   * Promise that resolves when the last active animation is stopped (including
+   * when the animation finishes naturally).
+   *
+   * @remarks
+   * The Promise returned by this method is reset every time the animation
+   * enters a new start/stop cycle. This means you must call `start()` before
+   * calling this method if you want to wait for the animation to stop.
+   *
+   * This method always returns a resolved promise if the animation is currently
+   * in a stopped state.
+   *
+   * @returns
+   */
+  waitUntilStopped(): Promise<void>;
+  /**
+   * Current state of the animation
+   *
+   * @remarks
+   * - `stopped` - The animation is currently stopped (at the beggining or end
+   *   of the animation)
+   * - `running` - The animation is currently running
+   * - `paused` - The animation is currently paused
+   */
+  readonly state: AnimationControllerState;
+
+  on: (
+    e: string,
+    cb: (controller: IAnimationController, props?: any) => void,
+  ) => void;
 }
 
-/** Based on {@link lng.INodeProps} */
-export interface IRendererNodeProps
-  extends Omit<lng.INodeProps, 'shader' | 'parent'> {
-  shader: IRendererShader | null;
-  parent: IRendererNode | null;
+export type CustomDataMap = {
+  [key: string]: string | number | boolean | undefined;
+};
+
+export { TextureType, type TextureMap } from 'lngr2';
+
+export interface TextureOptions {
+  /**
+   * Preload the texture immediately even if it's not being rendered to the
+   * screen.
+   *
+   * @remarks
+   * This allows the texture to be used immediately without any delay when it
+   * is first needed for rendering. Otherwise the loading process will start
+   * when the texture is first rendered, which may cause a delay in that texture
+   * being shown properly.
+   *
+   * @defaultValue `false`
+   */
+  preload?: boolean;
+  /**
+   * Prevent clean up of the texture when it is no longer being used.
+   *
+   * @remarks
+   * This is useful when you want to keep the texture in memory for later use.
+   * Regardless of whether the texture is being used or not, it will not be
+   * cleaned up.
+   *
+   * @defaultValue `false`
+   */
+  preventCleanup?: boolean;
+  /**
+   * Flip the texture horizontally when rendering
+   *
+   * @defaultValue `false`
+   */
+  flipX?: boolean;
+  /**
+   * Flip the texture vertically when rendering
+   *
+   * @defaultValue `false`
+   */
+  flipY?: boolean;
+  /**
+   * You can use resizeMode to determine the clipping automatically from the width
+   * and height of the source texture. This can be convenient if you are unsure about
+   * the exact image sizes but want the image to cover a specific area.
+   *
+   * The resize modes cover and contain are supported
+   */
+  resizeMode?: ResizeModeOptions;
 }
-/** Based on {@link lng.INode} */
+
+export interface ResizeModeOptionsCover {
+  /**
+   * Specifies that the image should be resized to cover the specified dimensions.
+   */
+  type: 'cover';
+  /**
+   * The horizontal clipping position
+   * To clip the left, set clipX to 0. To clip the right, set clipX to 1.
+   * clipX 0.5 will clip a equal amount from left and right
+   *
+   * @defaultValue 0.5
+   */
+  clipX?: number;
+  /**
+   * The vertical clipping position
+   * To clip the top, set clipY to 0. To clip the bottom, set clipY to 1.
+   * clipY 0.5 will clip a equal amount from top and bottom
+   *
+   * @defaultValue 0.5
+   */
+  clipY?: number;
+}
+export interface ResizeModeOptionsContain {
+  /**
+   * Specifies that the image should be resized to fit within the specified dimensions.
+   */
+  type: 'contain';
+}
+export type ResizeModeOptions =
+  | ResizeModeOptionsCover
+  | ResizeModeOptionsContain;
+
+/** Based on {@link lngr2.INodeProps} and {@link lngr2.CoreNodeProps} */
+export interface IRendererNodeProps {
+  /**
+   * The x coordinate of the Node's Mount Point.
+   *
+   * @remarks
+   * See {@link mountX} and {@link mountY} for more information about setting
+   * the Mount Point.
+   *
+   * @default `0`
+   */
+  x: number;
+  /**
+   * The y coordinate of the Node's Mount Point.
+   *
+   * @remarks
+   * See {@link mountX} and {@link mountY} for more information about setting
+   * the Mount Point.
+   *
+   * @default `0`
+   */
+  y: number;
+  /**
+   * The width of the Node.
+   *
+   * @default `0`
+   */
+  width: number;
+  /**
+   * The height of the Node.
+   *
+   * @default `0`
+   */
+  height: number;
+  /**
+   * The alpha opacity of the Node.
+   *
+   * @remarks
+   * The alpha value is a number between 0 and 1, where 0 is fully transparent
+   * and 1 is fully opaque.
+   *
+   * @default `1`
+   */
+  alpha: number;
+  /**
+   * Autosize mode
+   *
+   * @remarks
+   * When enabled, when a texture is loaded into the Node, the Node will
+   * automatically resize to the dimensions of the texture.
+   *
+   * Text Nodes are always autosized based on their text content regardless
+   * of this mode setting.
+   *
+   * @default `false`
+   */
+  autosize: boolean;
+  /**
+   * Margin around the Node's bounds for preloading
+   *
+   * @default `null`
+   */
+  boundsMargin: number | [number, number, number, number] | null;
+  /**
+   * Clipping Mode
+   *
+   * @remarks
+   * Enable Clipping Mode when you want to prevent the drawing of a Node and
+   * its descendants from overflowing outside of the Node's x/y/width/height
+   * bounds.
+   *
+   * For WebGL, clipping is implemented using the high-performance WebGL
+   * operation scissor. As a consequence, clipping does not work for
+   * non-rectangular areas. So, if the element is rotated
+   * (by itself or by any of its ancestors), clipping will not work as intended.
+   *
+   * TODO: Add support for non-rectangular clipping either automatically or
+   * via Render-To-Texture.
+   *
+   * @default `false`
+   */
+  clipping: boolean;
+  /**
+   * The color of the Node.
+   *
+   * @remarks
+   * The color value is a number in the format 0xRRGGBBAA, where RR is the red
+   * component, GG is the green component, BB is the blue component, and AA is
+   * the alpha component.
+   *
+   * Gradient colors may be set by setting the different color sub-properties:
+   * {@link colorTop}, {@link colorBottom}, {@link colorLeft}, {@link colorRight},
+   * {@link colorTl}, {@link colorTr}, {@link colorBr}, {@link colorBl} accordingly.
+   *
+   * @default `0xffffffff` (opaque white)
+   */
+  color: number;
+  /**
+   * The color of the top edge of the Node for gradient rendering.
+   *
+   * @remarks
+   * See {@link color} for more information about color values and gradient
+   * rendering.
+   */
+  colorTop: number;
+  /**
+   * The color of the bottom edge of the Node for gradient rendering.
+   *
+   * @remarks
+   * See {@link color} for more information about color values and gradient
+   * rendering.
+   */
+  colorBottom: number;
+  /**
+   * The color of the left edge of the Node for gradient rendering.
+   *
+   * @remarks
+   * See {@link color} for more information about color values and gradient
+   * rendering.
+   */
+  colorLeft: number;
+  /**
+   * The color of the right edge of the Node for gradient rendering.
+   *
+   * @remarks
+   * See {@link color} for more information about color values and gradient
+   * rendering.
+   */
+  colorRight: number;
+  /**
+   * The color of the top-left corner of the Node for gradient rendering.
+   *
+   * @remarks
+   * See {@link color} for more information about color values and gradient
+   * rendering.
+   */
+  colorTl: number;
+  /**
+   * The color of the top-right corner of the Node for gradient rendering.
+   *
+   * @remarks
+   * See {@link color} for more information about color values and gradient
+   * rendering.
+   */
+  colorTr: number;
+  /**
+   * The color of the bottom-right corner of the Node for gradient rendering.
+   *
+   * @remarks
+   * See {@link color} for more information about color values and gradient
+   * rendering.
+   */
+  colorBr: number;
+  /**
+   * The color of the bottom-left corner of the Node for gradient rendering.
+   *
+   * @remarks
+   * See {@link color} for more information about color values and gradient
+   * rendering.
+   */
+  colorBl: number;
+  /**
+   * The Node's parent Node.
+   *
+   * @remarks
+   * The value `null` indicates that the Node has no parent. This may either be
+   * because the Node is the root Node of the scene graph, or because the Node
+   * has been removed from the scene graph.
+   *
+   * In order to make sure that a Node can be rendered on the screen, it must
+   * be added to the scene graph by setting it's parent property to a Node that
+   * is already in the scene graph such as the root Node.
+   *
+   * @default `null`
+   */
+  parent: IRendererNode | null;
+  /**
+   * The Node's z-index.
+   *
+   * @remarks
+   * TBD
+   */
+  zIndex: number;
+  /**
+   * The Node's Texture.
+   *
+   * @remarks
+   * The `texture` defines a rasterized image that is contained within the
+   * {@link width} and {@link height} dimensions of the Node. If null, the
+   * Node will use an opaque white {@link ColorTexture} when being drawn, which
+   * essentially enables colors (including gradients) to be drawn.
+   *
+   * If set, by default, the texture will be drawn, as is, stretched to the
+   * dimensions of the Node. This behavior can be modified by setting the TBD
+   * and TBD properties.
+   *
+   * To create a Texture in order to set it on this property, call
+   * {@link RendererMain.createTexture}.
+   *
+   * If the {@link src} is set on a Node, the Node will use the
+   * {@link ImageTexture} by default and the Node will simply load the image at
+   * the specified URL.
+   *
+   * Note: If this is a Text Node, the Texture will be managed by the Node's
+   * {@link TextRenderer} and should not be set explicitly.
+   */
+  texture: IRendererTexture | null;
+  /**
+   * [Deprecated]: Prevents the texture from being cleaned up when the Node is removed
+   *
+   * @remarks
+   * Please use the `preventCleanup` property on {@link TextureOptions} instead.
+   *
+   * @default false
+   */
+  preventCleanup?: boolean;
+  /**
+   * Options to associate with the Node's Texture
+   */
+  textureOptions: TextureOptions;
+  /**
+   * The Node's shader
+   *
+   * @remarks
+   * The `shader` defines a {@link Shader} used to draw the Node. By default,
+   * the Default Shader is used which simply draws the defined {@link texture}
+   * or {@link color}(s) within the Node without any special effects.
+   *
+   * To create a Shader in order to set it on this property, call
+   * {@link RendererMain.createShader}.
+   *
+   * Note: If this is a Text Node, the Shader will be managed by the Node's
+   * {@link TextRenderer} and should not be set explicitly.
+   */
+  shader: IRendererShader;
+  /**
+   * Image URL
+   *
+   * @remarks
+   * When set, the Node's {@link texture} is automatically set to an
+   * {@link ImageTexture} using the source image URL provided (with all other
+   * settings being defaults)
+   */
+  src: string | null;
+  zIndexLocked: number;
+  /**
+   * Scale to render the Node at
+   *
+   * @remarks
+   * The scale value multiplies the provided {@link width} and {@link height}
+   * of the Node around the Node's Pivot Point (defined by the {@link pivot}
+   * props).
+   *
+   * Behind the scenes, setting this property sets both the {@link scaleX} and
+   * {@link scaleY} props to the same value.
+   *
+   * NOTE: When the scaleX and scaleY props are explicitly set to different values,
+   * this property returns `null`. Setting `null` on this property will have no
+   * effect.
+   *
+   * @default 1.0
+   */
+  scale: number | null;
+  /**
+   * Scale to render the Node at (X-Axis)
+   *
+   * @remarks
+   * The scaleX value multiplies the provided {@link width} of the Node around
+   * the Node's Pivot Point (defined by the {@link pivot} props).
+   *
+   * @default 1.0
+   */
+  scaleX: number;
+  /**
+   * Scale to render the Node at (Y-Axis)
+   *
+   * @remarks
+   * The scaleY value multiplies the provided {@link height} of the Node around
+   * the Node's Pivot Point (defined by the {@link pivot} props).
+   *
+   * @default 1.0
+   */
+  scaleY: number;
+  /**
+   * Combined position of the Node's Mount Point
+   *
+   * @remarks
+   * The value can be any number between `0.0` and `1.0`:
+   * - `0.0` defines the Mount Point at the top-left corner of the Node.
+   * - `0.5` defines it at the center of the Node.
+   * - `1.0` defines it at the bottom-right corner of the node.
+   *
+   * Use the {@link mountX} and {@link mountY} props seperately for more control
+   * of the Mount Point.
+   *
+   * When assigned, the same value is also passed to both the {@link mountX} and
+   * {@link mountY} props.
+   *
+   * @default 0 (top-left)
+   */
+  mount: number;
+  /**
+   * X position of the Node's Mount Point
+   *
+   * @remarks
+   * The value can be any number between `0.0` and `1.0`:
+   * - `0.0` defines the Mount Point's X position as the left-most edge of the
+   *   Node
+   * - `0.5` defines it as the horizontal center of the Node
+   * - `1.0` defines it as the right-most edge of the Node.
+   *
+   * The combination of {@link mountX} and {@link mountY} define the Mount Point
+   *
+   * @default 0 (left-most edge)
+   */
+  mountX: number;
+  /**
+   * Y position of the Node's Mount Point
+   *
+   * @remarks
+   * The value can be any number between `0.0` and `1.0`:
+   * - `0.0` defines the Mount Point's Y position as the top-most edge of the
+   *   Node
+   * - `0.5` defines it as the vertical center of the Node
+   * - `1.0` defines it as the bottom-most edge of the Node.
+   *
+   * The combination of {@link mountX} and {@link mountY} define the Mount Point
+   *
+   * @default 0 (top-most edge)
+   */
+  mountY: number;
+  /**
+   * Combined position of the Node's Pivot Point
+   *
+   * @remarks
+   * The value can be any number between `0.0` and `1.0`:
+   * - `0.0` defines the Pivot Point at the top-left corner of the Node.
+   * - `0.5` defines it at the center of the Node.
+   * - `1.0` defines it at the bottom-right corner of the node.
+   *
+   * Use the {@link pivotX} and {@link pivotY} props seperately for more control
+   * of the Pivot Point.
+   *
+   * When assigned, the same value is also passed to both the {@link pivotX} and
+   * {@link pivotY} props.
+   *
+   * @default 0.5 (center)
+   */
+  pivot: number;
+  /**
+   * X position of the Node's Pivot Point
+   *
+   * @remarks
+   * The value can be any number between `0.0` and `1.0`:
+   * - `0.0` defines the Pivot Point's X position as the left-most edge of the
+   *   Node
+   * - `0.5` defines it as the horizontal center of the Node
+   * - `1.0` defines it as the right-most edge of the Node.
+   *
+   * The combination of {@link pivotX} and {@link pivotY} define the Pivot Point
+   *
+   * @default 0.5 (centered on x-axis)
+   */
+  pivotX: number;
+  /**
+   * Y position of the Node's Pivot Point
+   *
+   * @remarks
+   * The value can be any number between `0.0` and `1.0`:
+   * - `0.0` defines the Pivot Point's Y position as the top-most edge of the
+   *   Node
+   * - `0.5` defines it as the vertical center of the Node
+   * - `1.0` defines it as the bottom-most edge of the Node.
+   *
+   * The combination of {@link pivotX} and {@link pivotY} define the Pivot Point
+   *
+   * @default 0.5 (centered on y-axis)
+   */
+  pivotY: number;
+  /**
+   * Rotation of the Node (in Radians)
+   *
+   * @remarks
+   * Sets the amount to rotate the Node by around it's Pivot Point (defined by
+   * the {@link pivot} props). Positive values rotate the Node clockwise, while
+   * negative values rotate it counter-clockwise.
+   *
+   * Example values:
+   * - `-Math.PI / 2`: 90 degree rotation counter-clockwise
+   * - `0`: No rotation
+   * - `Math.PI / 2`: 90 degree rotation clockwise
+   * - `Math.PI`: 180 degree rotation clockwise
+   * - `3 * Math.PI / 2`: 270 degree rotation clockwise
+   * - `2 * Math.PI`: 360 rotation clockwise
+   */
+  rotation: number;
+  /**
+   * Whether the Node is rendered to a texture
+   *
+   * @remarks
+   * TBD
+   *
+   * @default false
+   */
+  rtt: boolean;
+  /**
+   * Node data element for custom data storage (optional)
+   *
+   * @remarks
+   * This property is used to store custom data on the Node as a key/value data store.
+   * Data values are limited to string, numbers, booleans. Strings will be truncated
+   * to a 2048 character limit for performance reasons.
+   *
+   * This is not a data storage mechanism for large amounts of data please use a
+   * dedicated data storage mechanism for that.
+   *
+   * The custom data will be reflected in the inspector as part of `data-*` attributes
+   *
+   * @default `undefined`
+   */
+  data?: CustomDataMap;
+  /**
+   * Image Type to explicitly set the image type that is being loaded
+   *
+   * @remarks
+   * This property must be used with a `src` that points at an image. In some cases
+   * the extension doesn't provide a reliable representation of the image type. In such
+   * cases set the ImageType explicitly.
+   *
+   * `regular` is used for normal images such as png, jpg, etc
+   * `compressed` is used for ETC1/ETC2 compressed images with a PVR or KTX container
+   * `svg` is used for scalable vector graphics
+   *
+   * @default `undefined`
+   */
+  imageType?: 'regular' | 'compressed' | 'svg' | null;
+  /**
+   * She width of the rectangle from which the Image Texture will be extracted.
+   * This value can be negative. If not provided, the image's source natural
+   * width will be used.
+   */
+  srcWidth?: number;
+  /**
+   * The height of the rectangle from which the Image Texture will be extracted.
+   * This value can be negative. If not provided, the image's source natural
+   * height will be used.
+   */
+  srcHeight?: number;
+  /**
+   * The x coordinate of the reference point of the rectangle from which the Texture
+   * will be extracted.  `width` and `height` are provided. And only works when
+   * createImageBitmap is available. Only works when createImageBitmap is supported on the browser.
+   */
+  srcX?: number;
+  /**
+   * The y coordinate of the reference point of the rectangle from which the Texture
+   * will be extracted. Only used when source `srcWidth` width and `srcHeight` height
+   * are provided. Only works when createImageBitmap is supported on the browser.
+   */
+  srcY?: number;
+  /**
+   * By enabling Strict bounds the renderer will not process & render child nodes of a node that is out of the visible area
+   *
+   * @remarks
+   * When enabled out of bound nodes, i.e. nodes that are out of the visible area, will
+   * **NOT** have their children processed and renderer anymore. This means the children of a out of bound
+   * node will not receive update processing such as positioning updates and will not be drawn on screen.
+   * As such the rest of the branch of the update tree that sits below this node will not be processed anymore
+   *
+   * This is a big performance gain but may be disabled in cases where the width of the parent node is
+   * unknown and the render must process the child nodes regardless of the viewport status of the parent node
+   *
+   * @default false
+   */
+  strictBounds: boolean;
+  /**
+   * Mark the node as interactive so we can perform hit tests on it
+   * when pointer events are registered.
+   * @default false
+   */
+  interactive?: boolean;
+}
+
+/** Based on {@link lngr2.INode} */
 export interface IRendererNode extends IRendererNodeShaded, IRendererNodeProps {
   div?: HTMLElement;
   props: IRendererNodeProps;
-  renderState: lng.CoreNodeRenderState;
 }
 
-/** Based on {@link lng.ITextNodeProps} */
+/** Based on {@link lngr2.ITextNodeProps} */
 export interface IRendererTextNodeProps
-  extends Omit<lng.ITextNodeProps, 'shader' | 'parent'> {
+  extends Omit<lngr2.ITextNodeProps, 'shader' | 'parent'> {
   shader: IRendererShader | null;
   parent: IRendererNode | null;
 }
-/** Based on {@link lng.ITextNode} */
+/** Based on {@link lngr2.ITextNode} */
 export interface IRendererTextNode
   extends IRendererNodeShaded,
     IRendererTextNodeProps {
   div?: HTMLElement;
   props: IRendererTextNodeProps;
-  renderState: lng.CoreNodeRenderState;
 }
 
-/** Based on {@link lng.RendererMain} */
-export interface IRendererMain extends IEventEmitter {
+/** Based on {@link lngr2.RendererMain} */
+export interface IRendererMain {
   stage: IRendererStage;
   root: IRendererNode;
   createTextNode(props: Partial<IRendererTextNodeProps>): IRendererTextNode;
   createNode(props: Partial<IRendererNodeProps>): IRendererNode;
   createShader(kind: string, props: IRendererShaderProps): IRendererShader;
   createTexture(
-    kind: keyof lng.TextureMap,
+    kind: keyof lngr2.TextureMap,
     props: IRendererTextureProps,
   ): IRendererTexture;
   createEffect(
-    kind: keyof lng.EffectMap,
+    kind: keyof lngr2.EffectMap,
     props: Record<string, any>,
     name?: string,
-  ): lng.EffectDescUnion;
+  ): lngr2.EffectDescUnion;
+  on: (e: string, cb: (...a: any[]) => void) => void;
 }
 
 export let renderer: IRendererMain;
@@ -112,19 +753,21 @@ export let renderer: IRendererMain;
 export const getRenderer = () => renderer;
 
 export function startLightningRenderer(
-  options: lng.RendererMainSettings,
+  options: RendererOptions,
   rootId: string | HTMLElement = 'app',
 ) {
   renderer = DOM_RENDERING
     ? new DOMRendererMain(options, rootId)
-    : (new lng.RendererMain(options, rootId) as any as IRendererMain);
+    : LIGHTNING_RENDERER_V3
+      ? (new lngr3.RendererMain(options, rootId) as any as IRendererMain)
+      : (new lngr2.RendererMain(options, rootId) as any as IRendererMain);
   return renderer;
 }
 
 export function loadFonts(
   fonts: (
-    | lng.WebTrFontFaceOptions
-    | (Partial<lng.SdfTrFontFaceOptions> & { type: SdfFontType })
+    | lngr2.WebTrFontFaceOptions
+    | (Partial<lngr2.SdfTrFontFaceOptions> & { type: SdfFontType })
   )[],
 ) {
   for (const font of fonts) {
@@ -134,16 +777,29 @@ export function loadFonts(
       'type' in font &&
       (font.type === 'msdf' || font.type === 'ssdf')
     ) {
-      renderer.stage.fontManager.addFontFace(
-        new lng.SdfTrFontFace(font.type, {
+      let fontFace: any;
+      if (LIGHTNING_RENDERER_V3) {
+        fontFace = new lngr3.SdfTrFontFace(font.type, {
           ...font,
           stage: renderer.stage as any,
-        } as lng.SdfTrFontFaceOptions),
-      );
+        } as lngr3.SdfTrFontFaceOptions);
+      } else {
+        fontFace = new lngr2.SdfTrFontFace(font.type, {
+          ...font,
+          stage: renderer.stage as any,
+        } as lngr2.SdfTrFontFaceOptions);
+      }
+      renderer.stage.fontManager.addFontFace(fontFace);
     }
     // Canvas — Web
     else if ('fontUrl' in font) {
-      renderer.stage.fontManager.addFontFace(new lng.WebTrFontFace(font));
+      let fontFace: any;
+      if (LIGHTNING_RENDERER_V3) {
+        fontFace = new lngr3.WebTrFontFace(font);
+      } else {
+        fontFace = new lngr2.WebTrFontFace(font);
+      }
+      renderer.stage.fontManager.addFontFace(fontFace);
     }
   }
 }

--- a/src/nodeTypes.ts
+++ b/src/nodeTypes.ts
@@ -1,6 +1,0 @@
-export const NodeType = {
-  Element: 'element',
-  TextNode: 'textNode',
-  Text: 'text',
-} as const;
-export type NodeTypes = (typeof NodeType)[keyof typeof NodeType];

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -1,0 +1,548 @@
+import * as lngr3 from 'lngr3';
+import * as lngr_shaders from 'lngr3/webgl/shaders';
+
+import type {
+  RoundedProps as ShaderRoundedProps,
+  ShadowProps as ShaderShadowProps,
+  HolePunchProps as ShaderHolePunchProps,
+  RadialGradientProps as ShaderRadialGradientProps,
+  LinearGradientProps as ShaderLinearGradientProps,
+} from 'lngr3';
+export {
+  ShaderRoundedProps,
+  ShaderShadowProps,
+  ShaderHolePunchProps,
+  ShaderRadialGradientProps,
+  ShaderLinearGradientProps,
+};
+
+import type { WebGlShaderType as WebGlShader } from 'lngr3/webgl';
+export { WebGlShader };
+
+import { type IRendererShaderManager } from './lightningInit.js';
+import {
+  DOM_RENDERING,
+  LIGHTNING_RENDERER_V3,
+  SHADERS_ENABLED,
+} from './config.js';
+
+export type Vec4 = [x: number, y: number, z: number, w: number];
+
+export interface ShaderBorderProps extends lngr3.BorderProps {
+  /** Distance between the border and element edges. */
+  gap: number;
+  /**
+   * If `true`, the border is drawn outside the element. \
+   * If `false`, the border is drawn inside the element.
+   * @default false
+   */
+  outset: boolean;
+}
+
+export type ShaderBorderPrefixedProps = {
+  [P in keyof ShaderBorderProps as `border-${P}`]: ShaderBorderProps[P];
+};
+export type ShaderShadowPrefixedProps = {
+  [P in keyof ShaderShadowProps as `shadow-${P}`]: ShaderShadowProps[P];
+};
+
+export type ShaderRoundedWithShadowProps = ShaderRoundedProps &
+  ShaderShadowPrefixedProps;
+export type ShaderRoundedWithBorderProps = ShaderRoundedProps &
+  ShaderBorderPrefixedProps;
+export type ShaderRoundedWithBorderAndShadowProps = ShaderRoundedProps &
+  ShaderShadowPrefixedProps &
+  ShaderBorderPrefixedProps;
+
+export type ShaderRounded = WebGlShader<ShaderRoundedProps>;
+export type ShaderShadow = WebGlShader<ShaderShadowProps>;
+export type ShaderRoundedWithBorder = WebGlShader<ShaderRoundedWithBorderProps>;
+export type ShaderRoundedWithShadow = WebGlShader<ShaderRoundedWithShadowProps>;
+export type ShaderRoundedWithBorderAndShadow =
+  WebGlShader<ShaderRoundedWithBorderAndShadowProps>;
+export type ShaderHolePunch = WebGlShader<ShaderHolePunchProps>;
+export type ShaderRadialGradient = WebGlShader<ShaderRadialGradientProps>;
+export type ShaderLinearGradient = WebGlShader<ShaderLinearGradientProps>;
+
+export const defaultShaderRounded: ShaderRounded = lngr_shaders.Rounded;
+export const defaultShaderShadow: ShaderShadow = lngr_shaders.Shadow;
+export const defaultShaderRoundedWithShadow: ShaderRoundedWithShadow =
+  lngr_shaders.RoundedWithShadow;
+// TODO: lngr_shaders.RoundedWithBorderAndShadow doesn't support border-gap
+export const defaultShaderRoundedWithBorderAndShadow =
+  lngr_shaders.RoundedWithBorderAndShadow as ShaderRoundedWithBorderAndShadow;
+export const defaultShaderHolePunch: ShaderHolePunch = lngr_shaders.HolePunch;
+export const defaultShaderRadialGradient: ShaderRadialGradient =
+  lngr_shaders.RadialGradient;
+export const defaultShaderLinearGradient: ShaderLinearGradient =
+  lngr_shaders.LinearGradient;
+
+function toValidVec4(value: unknown): Vec4 {
+  if (typeof value === 'number') {
+    return [value, value, value, value];
+  }
+  if (Array.isArray(value)) {
+    switch (value.length) {
+      default:
+      case 4:
+        return value as Vec4;
+      case 3:
+        return [value[0], value[1], value[2], value[0]];
+      case 2:
+        return [value[0], value[1], value[0], value[1]];
+      case 1:
+        return [value[0], value[0], value[0], value[0]];
+      case 0:
+        break;
+    }
+  }
+  return [0, 0, 0, 0];
+}
+
+const roundedWithBorderProps: lngr3.ShaderProps<ShaderRoundedWithBorderProps> =
+  {
+    radius: {
+      default: [0, 0, 0, 0],
+      resolve(value) {
+        return toValidVec4(value);
+      },
+    },
+    'top-left': {
+      default: 0,
+      set(value, props) {
+        (props.radius as Vec4)[0] = value;
+      },
+      get(props) {
+        return (props.radius as Vec4)[0];
+      },
+    },
+    'top-right': {
+      default: 0,
+      set(value, props) {
+        (props.radius as Vec4)[1] = value;
+      },
+      get(props) {
+        return (props.radius as Vec4)[1];
+      },
+    },
+    'bottom-right': {
+      default: 0,
+      set(value, props) {
+        (props.radius as Vec4)[2] = value;
+      },
+      get(props) {
+        return (props.radius as Vec4)[2];
+      },
+    },
+    'bottom-left': {
+      default: 0,
+      set(value, props) {
+        (props.radius as Vec4)[3] = value;
+      },
+      get(props) {
+        return (props.radius as Vec4)[3];
+      },
+    },
+    'border-width': {
+      default: [0, 0, 0, 0],
+      resolve(value) {
+        return toValidVec4(value);
+      },
+    },
+    'border-color': 0xffffffff,
+    'border-gap': 0,
+    'border-top': {
+      default: 0,
+      set(value, props) {
+        (props['border-width'] as Vec4)[0] = value;
+      },
+      get(props) {
+        return (props['border-width'] as Vec4)[0];
+      },
+    },
+    'border-right': {
+      default: 0,
+      set(value, props) {
+        (props['border-width'] as Vec4)[1] = value;
+      },
+      get(props) {
+        return (props['border-width'] as Vec4)[1];
+      },
+    },
+    'border-bottom': {
+      default: 0,
+      set(value, props) {
+        (props['border-width'] as Vec4)[2] = value;
+      },
+      get(props) {
+        return (props['border-width'] as Vec4)[2];
+      },
+    },
+    'border-left': {
+      default: 0,
+      set(value, props) {
+        (props['border-width'] as Vec4)[3] = value;
+      },
+      get(props) {
+        return (props['border-width'] as Vec4)[3];
+      },
+    },
+    'border-outset': true,
+  };
+
+export const defaultShaderRoundedWithBorder: ShaderRoundedWithBorder = {
+  props: roundedWithBorderProps,
+  canBatch: () => false,
+  update() {
+    let props = this.props!;
+    let borderWidth = props['border-width'] as Vec4;
+    let borderGap = props['border-gap'];
+    let outset = props['border-outset'];
+
+    this.uniformRGBA('u_borderColor', props['border-color']);
+    this.uniform4fa('u_border', borderWidth);
+    this.uniform1f('u_gap', borderGap);
+    this.uniform1i('u_outset', outset ? 1 : 0);
+
+    let [b_t, b_r, b_b, b_l] = borderWidth;
+    let borderZero = b_t === 0 && b_r === 0 && b_b === 0 && b_l === 0;
+    this.uniform1i('u_borderZero', borderZero ? 1 : 0);
+
+    this.uniform4fa('u_radius_node', props.radius as Vec4);
+  },
+  vertex: /*glsl*/ `
+    # ifdef GL_FRAGMENT_PRECISION_HIGH
+    precision highp float;
+    # else
+    precision mediump float;
+    # endif
+
+    /* Passed by lightning renderer */
+    attribute vec2 a_position;
+    attribute vec2 a_textureCoords;
+    attribute vec4 a_color;
+    attribute vec2 a_nodeCoords;
+
+    uniform vec2 u_resolution;
+    uniform float u_pixelRatio;
+    uniform vec2 u_dimensions;
+
+    /* Passed by shader setup */
+    uniform vec4 u_radius_node;
+    uniform vec4 u_border;
+    uniform float u_gap;
+    uniform bool u_outset;
+    uniform bool u_borderZero;
+
+    varying vec4 v_color;
+    varying vec2 v_texcoords;
+    varying vec2 v_nodeCoords;
+    varying vec4 v_borderEndRadius;
+    varying vec2 v_borderEndSize;
+
+    varying vec4 v_innerRadius;
+    varying vec2 v_innerSize;
+    varying vec2 v_halfDimensions;
+    varying vec4 v_radius_border;
+
+    // Calculate factored radius to prevent self-intersection
+    vec4 calcFactoredRadius(vec4 radius, vec2 dimensions) {
+      float factor = 1.0;
+      factor = min(factor, dimensions.x / max(dimensions.x, radius.x + radius.y));
+      factor = min(factor, dimensions.x / max(dimensions.x, radius.z + radius.w));
+      factor = min(factor, dimensions.y / max(dimensions.y, radius.x + radius.w));
+      factor = min(factor, dimensions.y / max(dimensions.y, radius.y + radius.z));
+      return radius * factor;
+    }
+
+    void main() {
+      vec2 screen_space = vec2(2.0 / u_resolution.x, -2.0 / u_resolution.y);
+
+      v_color = a_color;
+      v_nodeCoords = a_nodeCoords;
+
+      float b_t = u_border.x;
+      float b_r = u_border.y;
+      float b_b = u_border.z;
+      float b_l = u_border.w;
+
+      vec2 rect_node   = u_dimensions;
+      vec2 rect_border = u_dimensions;
+      if (u_outset) {
+        // For outside borders, expand dimensions
+        rect_border.x += b_l + b_r + u_gap * 2.0;
+        rect_border.y += b_t + b_b + u_gap * 2.0;
+      }
+
+      // factored content radius
+      v_radius_border = calcFactoredRadius(u_radius_node, rect_node);
+
+      // For outside borders, add gap and border thickness to radius
+      if (u_outset) {
+        v_radius_border.x += u_gap + max(b_t, b_l); // top-left
+        v_radius_border.y += u_gap + max(b_t, b_r); // top-right
+        v_radius_border.z += u_gap + max(b_b, b_r); // bottom-right
+        v_radius_border.w += u_gap + max(b_b, b_l); // bottom-left
+        v_radius_border = calcFactoredRadius(v_radius_border, rect_border);
+      }
+
+      // Calculate the offset to expand/contract the quad for border and gap
+      vec2 expansion_offset = vec2(0.0);
+      if (u_outset) {
+        // Outside border: expand the quad
+        if (a_nodeCoords.x == 0.0) { // Left edge vertex
+          expansion_offset.x = -(b_l + u_gap);
+        } else { // Right edge vertex (a_nodeCoords.x == 1.0)
+          expansion_offset.x =  (b_r + u_gap);
+        }
+        if (a_nodeCoords.y == 0.0) { // Top edge vertex
+          expansion_offset.y = -(b_t + u_gap);
+        } else { // Bottom edge vertex (a_nodeCoords.y == 1.0)
+          expansion_offset.y =  (b_b + u_gap);
+        }
+      }
+
+      // Texture coordinate calculation
+      v_texcoords = a_textureCoords;
+      if (u_outset) { // For outside borders, adjust texture coordinates for expansion
+        v_texcoords *= rect_border;
+        v_texcoords.x -= b_l + u_gap;
+        v_texcoords.y -= b_t + u_gap;
+        v_texcoords /= rect_node;
+      }
+
+      v_halfDimensions = rect_border * 0.5;
+      if (!u_borderZero) {
+
+        float gap_x2 = u_gap * 2.0;
+
+        if (u_outset) {
+          // For outside borders, calculate from expanded dimensions inward
+          v_borderEndRadius.x = v_radius_border.x - max(b_t, b_l) - 0.5;
+          v_borderEndRadius.y = v_radius_border.y - max(b_t, b_r) - 0.5;
+          v_borderEndRadius.z = v_radius_border.z - max(b_b, b_r) - 0.5;
+          v_borderEndRadius.w = v_radius_border.w - max(b_b, b_l) - 0.5;
+
+          v_borderEndSize = (rect_border - vec2(b_l + b_r, b_t + b_b) - 1.0) * 0.5;
+
+          v_innerRadius.x = v_radius_border.x - max(b_t, b_l) - u_gap - 0.5;
+          v_innerRadius.y = v_radius_border.y - max(b_t, b_r) - u_gap - 0.5;
+          v_innerRadius.z = v_radius_border.z - max(b_b, b_r) - u_gap - 0.5;
+          v_innerRadius.w = v_radius_border.w - max(b_b, b_l) - u_gap - 0.5;
+
+          v_innerSize.x = rect_border.x - (b_l + b_r) - gap_x2 - 1.0;
+          v_innerSize.y = rect_border.y - (b_t + b_b) - gap_x2 - 1.0;
+          v_innerSize *= 0.5;
+        } else {
+          // For inset borders, flip the meaning:
+          // v_borderEndRadius/Size represents the gap area
+          // v_innerRadius/Size represents the border area
+
+          // Gap area (v_borderEnd represents gap boundary) - uniform gap
+          v_borderEndRadius = v_radius_border - u_gap - 0.5;
+          v_borderEndSize = (rect_border - gap_x2 - 1.0) * 0.5;
+
+          // Border area (v_inner represents border boundary) - individual border widths
+          v_innerRadius.x = v_radius_border.x - u_gap - max(b_t, b_l) - 0.5;
+          v_innerRadius.y = v_radius_border.y - u_gap - max(b_t, b_r) - 0.5;
+          v_innerRadius.z = v_radius_border.z - u_gap - max(b_b, b_r) - 0.5;
+          v_innerRadius.w = v_radius_border.w - u_gap - max(b_b, b_l) - 0.5;
+
+          v_innerSize = (rect_border - gap_x2 - vec2(b_l + b_r, b_t + b_b) - 1.0) * 0.5;
+        }
+
+        v_borderEndRadius = max(v_borderEndRadius, vec4(0.0));
+        v_innerRadius     = max(v_innerRadius, vec4(0.0));
+      }
+
+      vec2 normalized = (a_position + expansion_offset) * u_pixelRatio;
+
+      gl_Position = vec4(normalized.x * screen_space.x - 1.0, normalized.y * -abs(screen_space.y) + 1.0, 0.0, 1.0);
+      gl_Position.y = -sign(screen_space.y) * gl_Position.y;
+    }
+  `,
+  fragment: /*glsl*/ `
+    # ifdef GL_FRAGMENT_PRECISION_HIGH
+    precision highp float;
+    # else
+    precision mediump float;
+    # endif
+
+    /* Passed by lightning renderer */
+    uniform vec2 u_resolution;
+    uniform float u_pixelRatio;
+    uniform float u_alpha;
+    uniform vec2 u_dimensions;
+    uniform sampler2D u_texture;
+
+    /* Passed by shader setup */
+    uniform vec4 u_border;
+    uniform vec4 u_borderColor;
+    uniform bool u_outset;
+    uniform bool u_borderZero;
+
+    varying vec4 v_borderEndRadius;
+    varying vec2 v_borderEndSize;
+
+    varying vec4 v_color;
+    varying vec2 v_texcoords;
+    varying vec2 v_nodeCoords;
+
+    varying vec2 v_halfDimensions;
+    varying vec4 v_innerRadius;
+    varying vec2 v_innerSize;
+    varying vec4 v_radius_border;
+
+    float roundedBox(vec2 p, vec2 s, vec4 r) {
+      r.xy = (p.x > 0.0) ? r.yz : r.xw;
+      r.x = (p.y > 0.0) ? r.y : r.x;
+      vec2 q = abs(p) - s + r.x;
+      return (min(max(q.x, q.y), 0.0) + length(max(q, 0.0))) - r.x;
+    }
+
+    void main() {
+      vec4 contentTexColor = texture2D(u_texture, v_texcoords) * v_color;
+
+      vec2 boxUv = v_nodeCoords.xy * (v_halfDimensions * 2.0) - v_halfDimensions;
+      float outerShapeDist = roundedBox(boxUv, v_halfDimensions, v_radius_border);
+      float outerShapeAlpha = 1.0 - smoothstep(0.0, 1.0, outerShapeDist); // 1 inside, 0 outside
+
+      if (u_borderZero) { // No border, effectively no gap from border logic
+        gl_FragColor = mix(vec4(0.0), contentTexColor, outerShapeAlpha) * u_alpha;
+        return;
+      }
+
+      // Adjust boxUv for non-uniform borders
+      // This adjusted UV is used for calculating distances to border-end and content shapes
+      vec2 adjustedBoxUv = boxUv;
+      vec2 borderAdjustedBoxUv = boxUv;
+
+      if (u_outset) {
+        // For outside borders, use same adjustment for both calculations
+        adjustedBoxUv.x += (u_border.y - u_border.w) * 0.5;
+        adjustedBoxUv.y += (u_border.z - u_border.x) * 0.5;
+        borderAdjustedBoxUv = adjustedBoxUv;
+      } else {
+        // For inset borders, gap calculation uses no adjustment (uniform gap)
+        // Border calculation uses adjustment (non-uniform border)
+        borderAdjustedBoxUv.x += (u_border.y - u_border.w) * 0.5;
+        borderAdjustedBoxUv.y += (u_border.z - u_border.x) * 0.5;
+      }
+
+      // Distance to the inner edge of the border (where the gap begins)
+      float borderEndDist = roundedBox(adjustedBoxUv, v_borderEndSize, v_borderEndRadius);
+      float borderEndAlpha = 1.0 - smoothstep(0.0, 1.0, borderEndDist); // 1 if inside gap or content, 0 if in border or outside
+
+      // Distance to the content area (after the gap)
+      float contentDist = roundedBox(borderAdjustedBoxUv, v_innerSize, v_innerRadius);
+      float contentAlpha = 1.0 - smoothstep(0.0, 1.0, contentDist); // 1 if inside content, 0 if in gap, border or outside
+
+      vec4 finalColor;
+      // For outside borders: element -> gap -> border
+      if (u_outset) {
+        // Pixel is inside the content area
+        if (contentAlpha > 0.0) {
+          finalColor = contentTexColor;
+        }
+        // Pixel is inside the gap area
+        else if (borderEndAlpha > 0.0) {
+          finalColor = vec4(0.0); // Transparent gap
+        }
+        // Pixel is inside the border area
+        else {
+          vec4 borderColor = u_borderColor;
+          finalColor = borderColor;
+          finalColor.rgb *= finalColor.a;
+        }
+      }
+      // For inset borders: border <- gap <- element
+      // flip the logic: borderEndAlpha becomes gap, contentAlpha becomes border+content
+      else {
+        // Pixel is inside the content area (innermost)
+        if (contentAlpha > 0.0) {
+          finalColor = contentTexColor;
+        }
+        // Pixel is inside the border area (middle)
+        else if (borderEndAlpha > 0.0) {
+          vec4 borderColor = u_borderColor;
+          finalColor = mix(contentTexColor, vec4(borderColor.rgb, 1.0), borderColor.a);
+        }
+        // Pixel is in the gap area (outermost) - show content through gap
+        else {
+          finalColor = contentTexColor;
+        }
+      }
+
+      gl_FragColor = mix(vec4(0.0), finalColor, outerShapeAlpha) * u_alpha;
+    }
+  `,
+};
+
+export function registerDefaultShaderRounded(
+  shManager: IRendererShaderManager,
+) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING)
+    shManager.registerShaderType('rounded', defaultShaderRounded);
+}
+export function registerDefaultShaderShadow(shManager: IRendererShaderManager) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING)
+    shManager.registerShaderType('shadow', defaultShaderShadow);
+}
+export function registerDefaultShaderRoundedWithBorder(
+  shManager: IRendererShaderManager,
+) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING)
+    shManager.registerShaderType(
+      'roundedWithBorder',
+      defaultShaderRoundedWithBorder,
+    );
+}
+export function registerDefaultShaderRoundedWithShadow(
+  shManager: IRendererShaderManager,
+) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING)
+    shManager.registerShaderType(
+      'roundedWithShadow',
+      defaultShaderRoundedWithShadow,
+    );
+}
+export function registerDefaultShaderRoundedWithBorderAndShadow(
+  shManager: IRendererShaderManager,
+) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING)
+    shManager.registerShaderType(
+      'roundedWithBorderWithShadow',
+      defaultShaderRoundedWithBorderAndShadow,
+    );
+}
+export function registerDefaultShaderHolePunch(
+  shManager: IRendererShaderManager,
+) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING)
+    shManager.registerShaderType('holePunch', defaultShaderHolePunch);
+}
+export function registerDefaultShaderRadialGradient(
+  shManager: IRendererShaderManager,
+) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING)
+    shManager.registerShaderType('radialGradient', defaultShaderRadialGradient);
+}
+export function registerDefaultShaderLinearGradient(
+  shManager: IRendererShaderManager,
+) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING)
+    shManager.registerShaderType('linearGradient', defaultShaderLinearGradient);
+}
+
+export function registerDefaultShaders(shManager: IRendererShaderManager) {
+  if (LIGHTNING_RENDERER_V3 && SHADERS_ENABLED && !DOM_RENDERING) {
+    registerDefaultShaderRounded(shManager);
+    registerDefaultShaderShadow(shManager);
+    registerDefaultShaderRoundedWithBorder(shManager);
+    registerDefaultShaderRoundedWithShadow(shManager);
+    registerDefaultShaderRoundedWithBorderAndShadow(shManager);
+    registerDefaultShaderHolePunch(shManager);
+    registerDefaultShaderRadialGradient(shManager);
+    registerDefaultShaderLinearGradient(shManager);
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
-import { type INode, type Point } from '@lightningjs/renderer';
 import { Config, isDev } from './config.js';
 import type { Styles, ElementText, TextNode } from './intrinsicTypes.js';
-import { ElementNode } from './elementNode.js';
-import { NodeType } from './nodeTypes.js';
+import { ElementNode, NodeType } from './elementNode.js';
+import { IRendererNode } from './lightningInit.js';
+
+export { assertTruthy, assertTruthy as assert, deg2Rad } from 'lngr2/utils';
 
 function hasDebug(node: any) {
   return isObject(node) && node.debug;
@@ -19,6 +20,14 @@ export function log(
     }
   }
 }
+
+export const keys: <T extends object>(obj: T) => (keyof T)[] =
+  Object.keys as any;
+export const values: <T extends object>(obj: T) => T[keyof T][] =
+  Object.values as any;
+export const entries: <T extends object>(
+  obj: T,
+) => { [K in keyof T]-?: [K, T[K]] }[keyof T][] = Object.entries as any;
 
 export const isFunc = (obj: unknown): obj is CallableFunction =>
   obj instanceof Function;
@@ -48,7 +57,7 @@ export function isInteger(item: unknown): item is number {
   return Number.isInteger(item);
 }
 
-export function isINode(node: object): node is INode {
+export function isINode(node: object): node is IRendererNode {
   return 'destroy' in node && typeof node.destroy === 'function';
 }
 
@@ -157,6 +166,10 @@ const node${i} = renderer.createNode(props${i});
   return output;
 }
 
+export interface Point {
+  x: number;
+  y: number;
+}
 export interface Rect extends Point {
   width: number;
   height: number;


### PR DESCRIPTION
- Switch lightning renderer version with `__LIGHTNING_RENDERER_V3__` static var

To do that:
- All types need to be allow for v2 and v3 values at the same time.
- Users shouldn't need to install lightning renderer directly (it's a dependency, not a peer dep), and use any apis imported directly from lightning renderer. Every feature should be provided by core. lightning renderer becomes implementation detail.

So there is some battling with types and adding static config to switch between webgl/canvas left to do.